### PR TITLE
Refactor and move roll queue to right

### DIFF
--- a/diceRoller/src/components/App.js
+++ b/diceRoller/src/components/App.js
@@ -1,154 +1,71 @@
-import React, {useState} from 'react'
-import {baseSkills} from '../services/skills.js'
-import {SkillList} from './SkillList.js'
+import React from 'react'
 import {useCharacterInfo} from './CharacterInfo.js'
-import {CharacterDetails} from './CharacterDetails.js'
-import {RollingList} from './RollingList.js'
+import {NavBar} from './NavBar.js'
+import {SkillTab} from './SkillTab.js'
 
 export default function App () {
-  const [rollQueue, setRollQueue] = useState([]);
-  const [count, setCount] = useState(0);
-    //const CharacterInfo = useCharacterInfo
   const botchActive = true; // I would like to make this a setting rule, but wanted to add it into the skill rolling immediately.  Change scope later.  
+  
+  const rollMethods = {
 
-  const {
-    characterName,
-    wounds, 
-    wildDie,
-    rank,
-    experience,
-    bennies,
-    pace,
-    toughness,
-    parry,
-  } = useCharacterInfo();
-  // return { wounds, wildDie, rank, experience, bennies, pace, toughness, parry };
-  // But whatever, I can always move it if I don't want it here.  
-    // That said, if I want to create a component to display these things, it's a pain if they aren't wrapped up together. 
-    // In the guide he ended up abstracting out state management to another object; does it make sense to abstract out all
-      // of the character state out to that object?  Less a component, it's where we keep all the character state.  
-      // Similarly, we could have state management for the global stuff once I get to that point.   
-  //skills = baseSkills;
+    roll(wildDie, dieType, multiActionPenalty, botchActive) {
+      let wildResult = rollMethods.rollExploding(wildDie);
+      let traitResult = rollMethods.rollExploding(dieType);
+      console.log(`Wild: ${wildResult} Trait: ${traitResult}`)    
+      let botch = rollMethods.botchCheck(wildResult, traitResult, botchActive);
+  
+      let rollResults = [wildResult, traitResult];
+      let multiActionPenaltyResults = rollMethods.handleMultiActionPenalty(rollResults, multiActionPenalty);
+      console.log(multiActionPenaltyResults);
+      console.log(`Highest value: ${Math.max(...multiActionPenaltyResults)}`);
+  
+      if (botch) {
+        console.log('Exiting, because you botched!')
+        return 'Botch!';
+      } else 
+        return Math.max(...multiActionPenaltyResults);
+    },
 
-  const addToRollQueue = (skillName) => {
-    console.log(skillName);
-    setRollQueue(rollQueue.concat(skillName));
-    console.log(rollQueue);
+    rollExploding(dieValue, total = 0) {
+      let rollResult = Math.ceil(Math.random()*dieValue)
+      console.log(`Result: ${rollResult} Die value: ${dieValue}`)
+      total = total + rollResult;
+      if (rollResult === dieValue) {
+        console.log('Explode!');
+        return rollMethods.rollExploding(dieValue, total);}
+      else (rollResult < dieValue) 
+          console.log('No explosions!');
+  
+          return total;
+    },
+  
+    botchCheck(wildResult, traitResult, botchActive) {
+      if (!botchActive) {
+        console.log('Botch rule is not active');
+        return false;
+      } else if (wildResult == 1 && traitResult == 1) {
+        return true;
+      } else 
+        return false;
+    },
+  
+    handleMultiActionPenalty(rollResults, multiActionPenalty) {
+      console.log(rollResults);
+      console.log(multiActionPenalty);
+      const updatedResults = rollResults.map(result => result > multiActionPenalty ? (result - multiActionPenalty) : 1); 
+      return updatedResults;
+    },
+
   }
-
-  const clearRollQueue = (rollQueue) => {
-    setRollQueue([]);
-    console.log(rollQueue);
-  }
-
-  const removeFromRollQueue = (skillName) => {
-    console.log(`Remove ${skillName}!`);
-    let remainingSkills = rollQueue.filter(skill => skill.name !== skillName);
-    setRollQueue(remainingSkills);
-  }
-
-  const roll = (wildDie, dieType, multiActionPenalty, botchActive) => {
-    let wildResult = rollExploding(wildDie);
-    let traitResult = rollExploding(dieType);
-    console.log(`Wild: ${wildResult} Trait: ${traitResult}`)    
-    let botch = botchCheck(wildResult, traitResult, botchActive);
-
-    let rollResults = [wildResult, traitResult];
-    let multiActionPenaltyResults = handleMultiActionPenalty(rollResults, multiActionPenalty);
-    console.log(multiActionPenaltyResults);
-    console.log(`Highest value: ${Math.max(...multiActionPenaltyResults)}`);
-
-    if (botch) {
-      console.log('Exiting, because you botched!')
-      return 'Botch!';
-    } else 
-      return Math.max(...multiActionPenaltyResults);
-  }
-
-  const rollExploding = (dieValue, total = 0) => {
-    let rollResult = Math.ceil(Math.random()*dieValue)
-    console.log(`Result: ${rollResult} Die value: ${dieValue}`)
-    total = total + rollResult;
-    if (rollResult === dieValue) {
-      console.log('Explode!');
-      return rollExploding(dieValue, total);}
-    else (rollResult < dieValue) 
-        console.log('No explosions!');
-
-        return total;
-  }
-
-  const botchCheck = (wildResult, traitResult, botchActive) => {
-    if (!botchActive) {
-      console.log('Botch rule is not active');
-      return false;
-    } else if (wildResult == 1 && traitResult == 1) {
-      return true;
-    } else 
-      return false;
-  }
-
-  const handleMultiActionPenalty = (rollResults, multiActionPenalty) => {
-    console.log(rollResults);
-    console.log(multiActionPenalty);
-    const updatedResults = rollResults.map(result => result > multiActionPenalty ? (result - multiActionPenalty) : 1); 
-    return updatedResults;
-  }
-    
-    // Seems like we want to handle MAP math first, then determine results.  
-    // I could decrease the amount of each value in the array by 2 (using map) and could even keep it from returning 0.  
-    // Then I return the higher value.  
-
-    // if (botch) {
-    //   console.log('Exiting, because you botched!')
-    //   return 'Botch!';
-    // } else if (wildResult > traitResult)
-    //   {console.log('Wild was greater!');
-    //   console.log(`MAP: ${multiActionPenalty}`);
-    //   return wildResult;
-    // }
-    // else if (wildResult < traitResult)
-    //   {console.log('Trait was greater!');
-    //   console.log(`MAP: ${multiActionPenalty}`);
-    //   return traitResult;
-    // }
-    // else if (wildResult === traitResult) 
-    //   {console.log('Tie!')
-    //   console.log(`MAP: ${multiActionPenalty}`);
-    //   return wildResult;
-    // }
-    // // I'd like to return an array at some point, but right now whatevs.  
-    // // let rollResults = [wildResult, traitResult]
-    // //return rollResults;
-    //   }
 
   return (
     <div>
-      {/* Can I spread the character details in here instead? */}
-      <CharacterDetails 
-        characterName={characterName}
-        wounds={wounds}
-        wildDie={wildDie}
-        rank={rank}
-        experience={experience}
-        bennies={bennies}
-        pace={pace}
-        toughness={toughness}
-        parry={parry}
-      />
-      <RollingList 
-        rollQueue={rollQueue}
-        onClick={roll}
-        wildDie={wildDie} // This feels like it should be global and that I don't need to pass it down... 
-        clearRollQueue={clearRollQueue}
-        removeFromRollQueue={removeFromRollQueue}
+      <NavBar />
+      <SkillTab 
+        rollMethods={rollMethods}
         botchActive={botchActive}
-      /> 
-
-      {/* <CharacterDetails {...useCharacterInfo} /> */}
-      <SkillList skills={baseSkills} 
-       addToRollQueue={addToRollQueue}
-      />
+        characterInfo={useCharacterInfo()}  // This is the React component, which is ultimately weird... but that's why I need to invoke it here.  Refactor away.
+        />
     </div>
   );
 }

--- a/diceRoller/src/components/CharacterDetails.js
+++ b/diceRoller/src/components/CharacterDetails.js
@@ -1,36 +1,36 @@
 import React from 'react';
 import { Paper, Typography } from '@material-ui/core'
 
-export const CharacterDetails = props => (
+export const CharacterDetails = ({characterInfo}) => {
+  
+    const {
+      characterName,
+      wounds, 
+      rank,
+      experience,
+      bennies,
+    } = characterInfo;
 
-  // {...useCharacterInfo} = this.props,
-  <Paper>
-    <Typography variant="h3"> 
-      Name: {props.characterName}
-    </Typography>
-    <Typography variant="h4">
-      <div>Wounds: {props.wounds}</div>
-      <div>Rank: {props.rank}</div>
-      <div>Experience: {props.experience}</div>
-      <div>Bennies: {props.bennies}</div>
-    </Typography>
-  </Paper>
-);
+    const style={
+      Paper: {
+        padding: 20,
+        marginTop: 5,
+        height: 200,
+        overflowY: 'auto',
+      }
+    }
 
-// export const CharacterDetails = ({characterName, wounds, rank, experience, bennies}) => (
-
-//   // {...useCharacterInfo} = this.props,
-//   <>
-//     <div>Name: {characterName}</div>
-//     <div>Wounds: {wounds} 
-//     {/* <button onClick={() => props.setWounds(props.wounds+1)}>Click me to update wounds.</button>*/}
-//     </div>
-//     <div>Rank: {rank}</div>
-//     <div>Experience: {experience}</div>
-//     <div>Bennies: {bennies}</div>
-//   </>
-//     //   <button onClick={() => setCount(count+1)}>
-//     //   {count}
-//     // </button>
-// );
-
+  return (
+    <Paper style={style.Paper}>
+      <Typography variant="h3"> 
+        Name: {characterName}
+      </Typography>
+      <Typography variant="h4">
+        <div>Wounds: {wounds}</div>
+        <div>Rank: {rank}</div>
+        <div>Experience: {experience}</div>
+        <div>Bennies: {bennies}</div>
+      </Typography>
+    </Paper>
+  );
+}

--- a/diceRoller/src/components/NavBar.js
+++ b/diceRoller/src/components/NavBar.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Paper, Tabs, Tab } from '@material-ui/core'
+
+export const NavBar = props => {
+  //const classes = useStyles();
+  const [value, setValue] = React.useState(1);
+
+  function handleChange(event, newValue) {
+    setValue(newValue);
+  }
+
+  // It appears that in order to really hook different pages up to each tab, I will need to utilize a Switch and react-router.  
+  // This basically assigns a URL to each page, and you link the tabs to those URLs.  The switch knows how to route things based on the path passed in from the tab.  I think?
+  // Here's a small sample I found:
+//   <BrowserRouter>
+//  <div className={classes.root}>
+//   <AppBar position="static" color="default">
+//     <Tabs
+//       value={this.state.value}
+//       onChange={this.handleChange}
+//     >
+//       <Tab label="Item One" component={Link} to="/one" />
+//       <Tab label="Item Two" component={Link} to="/two" />
+//     </Tabs>
+//   </AppBar>
+
+//   <Switch>
+//     <Route path="/one" component={PageShell(ItemOne)} />
+//     <Route path="/two" component={PageShell(ItemTwo)} />
+//   </Switch>
+// </div>
+
+  return (
+    <Paper > 
+      {/* className={classes.root}> */}
+      <Tabs
+        value={value}
+        onChange={handleChange}
+        indicatorColor="primary"
+        textColor="primary"
+        centered
+      >
+        <Tab label="Character Creator" />
+        <Tab label="Skill Rolling" />
+        <Tab label="Advancements" />
+      </Tabs>
+    </Paper>
+  );
+}

--- a/diceRoller/src/components/RollingList.js
+++ b/diceRoller/src/components/RollingList.js
@@ -2,60 +2,54 @@ import React from 'react'
 import { RollQueueSkill } from './RollQueueSkill.js'
 import { Button, Paper, Typography } from '@material-ui/core'
 
-export const RollingList = props => {
+export const RollingList = ({rollQueue, rollQueueMethods, rollMethods, wildDie, botchActive}) => {
 
   const style={
     Paper: {
       padding: 20,
+      marginTop: 5,
+      height: 500,
+      overflowY: 'auto',
     }
   }
 
-  const multiActionPenalty = (props.rollQueue.length - 1) * 2;
-
-  // Basically, this will display all of the elements in a "to-be-rolled" array.  
-    // Once all skills have been added to the queue, you may roll them in order (this is for MAP).  
-    // Add a maximum number of skills that can be added
-    // Add error display / explanation when trying to add greater than maximum skills.  
-    // These elements should have a clear button as well, to remove a skill before it's rolled.  
+  const multiActionPenalty = (rollQueue.length - 1) * 2;
 
   return (
     <Paper style={style.Paper}>
-    <>
-    <br />
-    <Typography variant="h4">
-      Roll Queue
-    </Typography>
-  </>
-    {props.rollQueue.length !== 0
-      ? <> 
-          {multiActionPenalty > 0
-          ? <Typography variant="h5" color="secondary">
-            Current penalty to every roll: {multiActionPenalty}
-            </Typography>
-          : null
-          }
+      <Typography variant="h4">
+        Roll Queue
+      </Typography>
+      {rollQueue.length !== 0
+        ? <> 
+            {multiActionPenalty > 0
+            ? <Typography variant="h5" color="secondary">
+              Current penalty to every roll: {multiActionPenalty}
+              </Typography>
+            : null
+            }
 
-          {props.rollQueue.map(skill => (
-            <RollQueueSkill 
-              key={skill.name} // I don't want to use this as a key because you can roll a skill >once.  But can't use index, because it isn't stable.  
-              skill={skill}
-              onClick={props.onClick}
-              removeFromRollQueue={props.removeFromRollQueue}
-              wildDie={props.wildDie}
-              multiActionPenalty={multiActionPenalty}
-              botchActive={props.botchActive}
-            /> 
-          )) } 
-          <Button 
-            variant="contained" 
-            color="primary" 
-            onClick={() => props.clearRollQueue(props.rollQueue)}
-          >
-              Clear all skills from queue
-          </Button>
-        </>
-      : null
-    }
+            {rollQueue.map(skill => (
+              <RollQueueSkill 
+                key={skill.name} // I don't want to use this as a key because you can roll a skill >once.  But can't use index, because it isn't stable.  
+                skill={skill}
+                onClick={rollMethods.roll}
+                removeFromRollQueue={rollQueueMethods.removeFromRollQueue}
+                wildDie={wildDie}
+                multiActionPenalty={multiActionPenalty}
+                botchActive={botchActive}
+              /> 
+            )) } 
+            <Button 
+              variant="contained" 
+              color="primary" 
+              onClick={() => rollQueueMethods.clearRollQueue(rollQueue)}
+            >
+                Clear all skills from queue
+            </Button>
+          </>
+        : null
+      }
     </Paper>
   );
 }

--- a/diceRoller/src/components/SkillButton.js
+++ b/diceRoller/src/components/SkillButton.js
@@ -1,15 +1,7 @@
 import React from 'react';
-//import { Button, Container } from '../../node_modules/@material-ui/core'
 import { Button, Card, Typography } from '@material-ui/core'
 
-export const SkillButton = props => {
-
-
-  // Display _something_ if the dieType is null.  
-  // I'd like to display a row of cells that contain the possible die types; might need a component for that which can be enabled / disabled
-  // Title case the names.  
-  // Only display the description and associatedAttribute onHover()
-    // To do this, I think I need to pass the function down from skill list as a prop
+export const SkillButton = ({skill, addToRollQueue}) => {
 
     const styles ={
       Card: {
@@ -24,14 +16,14 @@ export const SkillButton = props => {
         variant="h5" 
         //align="center"
       > 
-        {props.skill.name}
+        {skill.name}
       </Typography>
-      <Button variant="outlined" color="primary" onClick={() => props.addToRollQueue(props.skill)}>
-        Roll {props.skill.name}
+      <Button variant="outlined" color="primary" onClick={() => addToRollQueue(skill)}>
+        Roll {skill.name}
       </Button>
       <Typography variant="subtitle1">
-        <div>Die type: {props.skill.dieType}</div>
-        <div>Description: {props.skill.description}</div>
+        <div>Die type: {skill.dieType}</div>
+        <div>Description: {skill.description}</div>
       </Typography>
     </Card>
   );

--- a/diceRoller/src/components/SkillList.js
+++ b/diceRoller/src/components/SkillList.js
@@ -1,25 +1,33 @@
 import React from 'react';
 import {SkillButton} from './SkillButton.js'
-import { Grid } from '@material-ui/core'
+import { Grid, Paper } from '@material-ui/core'
 
-export const SkillList = props => {
-
+export const SkillList = ({skills, addToRollQueue}) => {
+//export const SkillList = props => {
   const style={
     Grid: {
+      padding: 0, // Intentional, will style later.
+    },
+    Paper: {
       padding: 20,
+      marginTop: 5,
+      height: 500,
+      overflowY: 'auto',
     }
   }
-  // Allow a show/hide option based on whether the skills are known (which means dieType !== null;)
+  
   return (
-    <Grid container justify="flex-start" spacing={2} style={style.Grid}>
-      {props.skills.map(skill => (
-        <Grid key={skill.name} item>
-          <SkillButton 
-            skill={skill}
-            addToRollQueue={props.addToRollQueue}
-          />
-        </Grid>
-        )) } 
-    </Grid>
+    <Paper style={style.Paper}>
+      <Grid container justify="flex-start" spacing={2} style={style.Grid}>
+        {skills.map(skill => (
+          <Grid key={skill.name} item>
+            <SkillButton 
+              skill={skill}
+              addToRollQueue={addToRollQueue}
+            />
+          </Grid>
+          )) } 
+      </Grid>
+    </Paper>
   );
 }

--- a/diceRoller/src/components/SkillTab.js
+++ b/diceRoller/src/components/SkillTab.js
@@ -1,0 +1,68 @@
+import React, {useState} from 'react';
+import {baseSkills} from '../services/skills.js'
+import {SkillList} from './SkillList.js'
+import {CharacterDetails} from './CharacterDetails.js'
+import {RollingList} from './RollingList.js'
+import {Grid} from '@material-ui/core';
+
+export const SkillTab = ({rollMethods, botchActive, characterInfo}) => {
+    const [rollQueue, setRollQueue] = useState([]);
+
+    const rollQueueMethods = {
+
+        addToRollQueue(skillName) {
+          console.log(skillName);
+          setRollQueue(rollQueue.concat(skillName));
+          console.log(rollQueue);
+        },
+    
+        clearRollQueue(rollQueue) {
+          setRollQueue([]);
+          console.log(rollQueue);
+        }, 
+    
+        removeFromRollQueue(skillName) {
+          console.log(`Remove ${skillName}!`);
+          let remainingSkills = rollQueue.filter(skill => skill.name !== skillName);
+          setRollQueue(remainingSkills);
+        },
+    
+      }
+
+    const { wildDie } = characterInfo;
+
+    return (
+      <div>
+        <CharacterDetails 
+          characterInfo={characterInfo}
+        />
+          <Grid container>
+          <Grid item sm>
+              <SkillList 
+                skills={baseSkills} 
+                addToRollQueue={rollQueueMethods.addToRollQueue}
+            />
+         
+            </Grid>
+              <Grid item sm>
+                <RollingList 
+                    rollQueue={rollQueue}
+                    rollQueueMethods={rollQueueMethods}
+                    rollMethods={rollMethods}
+                    wildDie={wildDie} // This feels like it should be global and that I don't need to pass it down... 
+                    botchActive={botchActive}
+                /> 
+
+              </Grid>
+          </Grid>
+        {/* Can I spread the character details in here instead? */}
+
+        
+        
+      </div>
+    );
+}
+
+// Once I start implementing a character creator tab, I will put that in a second component.  
+// Then I can apparently use react-router to hook these tabs to links in the NavBar component, which then allows me to switch which view displays.  
+


### PR DESCRIPTION
Created a grid to place the skill list and the roll queue in so they'd appear side-by-side.  Also refactored a few things (pushed rolling methods and roll queue add/remove methods into their own objects to ease passing them around, as well as destructured some props to make components easier to read.