### PR TITLE
Utilize grid to better handle height of elements

### DIFF
--- a/diceRoller/src/components/App.js
+++ b/diceRoller/src/components/App.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import { MuiThemeProvider } from '@material-ui/core'
-import {Paper} from "@material-ui/core"
 import {useCharacterInfo} from './CharacterInfo.js'
 import NavBar from './NavBar.js'
-import {SkillTab} from './SkillTab.js'
+import SkillTab from './SkillTab.js'
 
-export const App = () => {
+export default () => {
   const botchActive = true; // I would like to make this a setting rule, but wanted to add it into the skill rolling immediately.  Change scope later.  
   
   const rollMethods = {
@@ -61,13 +59,13 @@ export const App = () => {
   }
 
   return (
-      <Paper>
+      <>
         <NavBar />
         <SkillTab 
           rollMethods={rollMethods}
           botchActive={botchActive}
           characterInfo={useCharacterInfo()}  // This is the React component, which is ultimately weird... but that's why I need to invoke it here.  Refactor away.
         />
-      </Paper>
+      </>
   );
 }

--- a/diceRoller/src/components/CharacterDetails.js
+++ b/diceRoller/src/components/CharacterDetails.js
@@ -5,8 +5,11 @@ import { withStyles } from '@material-ui/core/styles'
 const styles = theme => ({
   paper: {
     padding: theme.spacing(3),
+    paddingBottom: theme.spacing(1),
     marginTop: theme.spacing(5),
     overflowY: 'auto',
+    //height: 'calc(25% - 40px)',
+    // minHeight: 200,
   },
 })
 
@@ -22,10 +25,10 @@ export default withStyles(styles)(({classes, characterInfo}) => {
 
   return (
     <Paper className={classes.paper}>
-      <Typography variant="h3">
+      <Typography variant="h4">
         Name: {characterName}
       </Typography>
-      <Typography variant="h4">
+      <Typography variant="h5">
         <div>Wounds: {wounds}</div>
         <div>Rank: {rank}</div>
         <div>Experience: {experience}</div>

--- a/diceRoller/src/components/RollingList.js
+++ b/diceRoller/src/components/RollingList.js
@@ -3,10 +3,15 @@ import RollQueueSkill from './RollQueueSkill.js'
 import { Button, Grid, Paper, Typography, withStyles } from '@material-ui/core'
 
 const styles = theme => ({
+  // '@global': {
+  //   'html, body, #root': {
+  //     height: '100%',
+  //   }
+  // },
   paper: {
     padding: theme.spacing(1.5),
     margin: theme.spacing(1.5),
-    height: 500,
+    height: '100%',
     overflowY: 'auto',
   }, 
   gridContainer: {

--- a/diceRoller/src/components/SkillButton.js
+++ b/diceRoller/src/components/SkillButton.js
@@ -8,6 +8,13 @@ const styles = theme => ({
   },
   header: {
     textTransform: 'capitalize',
+  }, 
+  textBlock: { // I started messing with flexing the layout of skills; didn't want to mess with padding right now.  
+    //flex: 2 
+  },
+  button: { // Really, should play with the breakpoints for these sorts of layout changes anyway.  
+    //flex: 1,
+    //flexShrink: 2,
   }
 })
 
@@ -19,6 +26,7 @@ export default withStyles(styles) (({classes, skill, addToRollQueue}) => {
         justify="space-between"
       >
       <div>
+         {/* className={classes.textBlock}> */}
         <Typography 
           className={classes.header} 
           variant='h5'
@@ -31,6 +39,7 @@ export default withStyles(styles) (({classes, skill, addToRollQueue}) => {
         </Typography>
       </div>
       <Button 
+        className={classes.button}
         variant="contained" 
         color="secondary"                  
         onClick={() => addToRollQueue(skill)}

--- a/diceRoller/src/components/SkillList.js
+++ b/diceRoller/src/components/SkillList.js
@@ -5,9 +5,9 @@ import { Grid, Paper, withStyles } from '@material-ui/core'
 const styles = theme => ({
   paper: {
     margin: theme.spacing(1.5),
-    height: 500,
     overflowY: 'auto',
-  }
+    height: '100%'
+  },
 })
 
 export default withStyles(styles) (({classes, skills, addToRollQueue}) => {

--- a/diceRoller/src/components/SkillTab.js
+++ b/diceRoller/src/components/SkillTab.js
@@ -3,9 +3,21 @@ import {baseSkills} from '../services/skills.js'
 import SkillList from './SkillList.js'
 import CharacterDetails from './CharacterDetails.js'
 import RollingList from './RollingList.js'
-import {Grid} from '@material-ui/core';
+import {Grid, withStyles} from '@material-ui/core';
 
-export const SkillTab = ({rollMethods, botchActive, characterInfo}) => {
+const styles = theme => ({
+  pageStyle: {
+    height: 'calc(100% - 24px)'
+  },
+  characterDetails: {
+    flex: 1
+  },
+  rollers: {
+    flex: 1,
+  }
+})
+
+export default withStyles(styles)(({classes, rollMethods, botchActive, characterInfo}) => {
   const [rollQueue, setRollQueue] = useState([]);
 
   const rollQueueMethods = {
@@ -32,11 +44,15 @@ export const SkillTab = ({rollMethods, botchActive, characterInfo}) => {
   const { wildDie } = characterInfo;
 
   return (
-    <div>
+    <Grid container 
+      className={classes.pageStyle}
+      direction="column"
+    >
       <CharacterDetails 
+        className={classes.characterDetails}
         characterInfo={characterInfo}
       />
-      <Grid container>
+      <Grid container className={classes.rollers}>
         <Grid item sm>
           <SkillList 
             skills={baseSkills} 
@@ -54,9 +70,9 @@ export const SkillTab = ({rollMethods, botchActive, characterInfo}) => {
         </Grid>
       </Grid>
       {/* Can I spread the character details in here instead? */}
-    </div>
+    </Grid>
   );
-}
+})
 
 // Once I start implementing a character creator tab, I will put that in a second component.  
 // Then I can apparently use react-router to hook these tabs to links in the NavBar component, which then allows me to switch which view displays.  

--- a/diceRoller/src/index.js
+++ b/diceRoller/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { MuiThemeProvider } from '@material-ui/core'
-import { App } from './components/App.js';
+import { MuiThemeProvider, CssBaseline } from '@material-ui/core'
+import App from './components/App.js';
 import theme from './theme.js'
 
 const commonTheme = theme;
@@ -9,6 +9,7 @@ const commonTheme = theme;
 ReactDOM.hydrate(
   <>
     <MuiThemeProvider theme={commonTheme}>
+      <CssBaseline />
       <App />
     </MuiThemeProvider>
   </>,

--- a/diceRoller/src/server/server.js
+++ b/diceRoller/src/server/server.js
@@ -4,7 +4,7 @@
 import express from 'express';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import {App} from '../components/App';
+import App from '../components/App';
 
 const server = express();
 server.use(express.static('dist'));


### PR DESCRIPTION
In short, I utilized two grids to get the skill list & roll queue to match the height of the browser; first, a column grid that contained the character details and a second grid container as the second child.  This second grid contained the skills and roll queue.  I applied flex sizing to everything, and it's all dynamic now.  I didn't do anything for improving the resizing of individual skills or the roll queue skills, nor did I implement any handling for mobile.  Felt more important to move onto routing!