### PR TITLE
Add character selection for skill roller

### DIFF
--- a/diceRoller/src/components/App.js
+++ b/diceRoller/src/components/App.js
@@ -2,9 +2,10 @@ import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 import NavBar from './NavBar.js'
 import Home from './Home'
-import SkillTab from './SkillTab.js'
+//import SkillTab from './SkillTab.js'
 import CharacterCreatorTab from './CharacterCreatorTab'
 import AdvancementTab from './AdvancementTab'
+import SkillRollerContainer from './SkillRollerContainer.js';
 
 export default () => {
   const botchActive = true; // I would like to make this a setting rule, but wanted to add it into the skill rolling immediately.  Change scope later.  
@@ -67,8 +68,8 @@ export default () => {
         <Switch>
           <Route exact path = '/' component={Home} />
           <Route path='/character-creator' component={CharacterCreatorTab} />
-          <Route path='/skill-rolling' render={
-            props => <SkillTab {...props} 
+          <Route path='/skill-roller/' render={
+            props => <SkillRollerContainer {...props} 
             rollMethods={rollMethods}
             botchActive={botchActive} /> } />
           <Route path='/advancement' component={AdvancementTab} />

--- a/diceRoller/src/components/NavBar.js
+++ b/diceRoller/src/components/NavBar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { AppBar, Tabs, Tab } from '@material-ui/core'
 import { withStyles } from '@material-ui/core/styles'
 import { Link, withRouter } from 'react-router-dom'
@@ -12,20 +12,20 @@ const styles = theme => (
 )
 
 export default withRouter(withStyles(styles)(({classes}) => {
-  const [value, setValue] = React.useState(1);
+  const [indicator, setIndicator] = useState(1);
   function handleChange(event, newValue) {
-    setValue(newValue);
+    setIndicator(newValue);
   }
 
   return (
     <AppBar>
       <Tabs
-        value={value}
+        value={indicator}
         onChange={handleChange}
         centered
       >
         <Tab label="Character Creator" className={classes.tabs} component={Link} to='/character-creator' />
-        <Tab label="Skill Rolling" className={classes.tabs} component={Link} to='/skill-rolling' />
+        <Tab label="Skill Rolling" className={classes.tabs} component={Link} to='/skill-roller' />
         <Tab label="Advancement" className={classes.tabs} component={Link} to='/advancement' />
       </Tabs>
     </AppBar>

--- a/diceRoller/src/components/SelectCharacter.js
+++ b/diceRoller/src/components/SelectCharacter.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Button, Typography } from '@material-ui/core'
+
+export default (props) => {
+  return(
+    <>
+      <br /><br /><br /><br />
+      <Typography variant="h3">
+        Please select a character.  
+      </Typography>
+      <Button>{props.character.characterName}</Button>
+
+
+    </>
+  )}

--- a/diceRoller/src/components/SkillRollerContainer.js
+++ b/diceRoller/src/components/SkillRollerContainer.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react'
+import { Button } from '@material-ui/core'
+import { Link, Route, Switch } from 'react-router-dom'
+import SkillTab from './SkillTab'
+//import SelectCharacter from './SelectCharacter'
+
+export default ( props ) => {
+  const [availableCharacters, setAvailableCharacters] = useState([]);
+  //console.log(`availableCharacters: ${availableCharacters}`);
+
+  // useEffect(() => {
+  //   const fetchPlayableCharacters = async () => {
+  //   const playableCharacters = await fetch('http://localhost:3002/characters')
+  //     .then(res => res.json())
+  //     .then(characters => {
+  //       characters.filter((character) => { 
+  //         console.log(character);
+  //         return character.playReady === true })
+  //     });
+  //     console.log(`availableCharacters: ${availableCharacters}`);
+  //     setAvailableCharacters(playableCharacters);
+  //   };
+  //   fetchPlayableCharacters();
+  // }, [])
+
+  useEffect(() => {
+    fetch('http://localhost:3002/characters')
+      .then(res => res.json())
+      .then(characters => {
+        console.log(characters)
+        const playableCharacters = characters.filter((character) => { 
+          return character.playReady === true })
+        setAvailableCharacters(playableCharacters)
+      })
+  }, [])
+
+return(
+  <Switch>
+    <Route path={`${props.match.url}/:id`} render={({ match }) => { 
+      const selectedCharacter = availableCharacters.find((character) => {
+          return character.characterName.replace(/\s+/g, '-').toLowerCase() === match.params.id})
+        return <SkillTab 
+          character={selectedCharacter} 
+          rollMethods={props.rollMethods}
+          botchActive={props.botchActive}  
+        /> 
+    }} />
+    <Route path='/skill-roller/' render={() => {
+      return (
+        <> 
+        
+          <br /><br /><br /><br /><br /><br /><br /><br />
+            Please select a character        
+
+        {/* Transform the characterName to utilize - (axel-prose) */}
+        {availableCharacters.map(character => (
+          //const tidyName = character.characterName.replace(/\s+/g, '-').toLowerCase()
+          //tidyName = tidyName.replace(/\s+/g, '-').toLowerCase();
+          <Link 
+            key={character.id} 
+            to={`${props.match.path}${character.characterName.replace(/\s+/g, '-').toLowerCase()}`}
+          >
+          <Button 
+            variant = 'contained' 
+            character={character}
+          >
+            {character.characterName}
+          </Button>
+        </Link>
+        
+        ))}
+     
+     </>) }} /> 
+      
+  </Switch>
+)}

--- a/diceRoller/src/components/SkillTab.js
+++ b/diceRoller/src/components/SkillTab.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import SkillList from './SkillList.js'
 import CharacterDetails from './CharacterDetails.js'
 import RollingList from './RollingList.js'
-import {Grid, withStyles} from '@material-ui/core';
+import { Grid, withStyles } from '@material-ui/core';
 
 const styles = theme => ({
   pageStyle: {
@@ -16,22 +16,19 @@ const styles = theme => ({
   }
 })
 
-export default withStyles(styles)(({classes, rollMethods, botchActive}) => {
+export default withStyles(styles)(({classes, rollMethods, botchActive, character}) => { 
   const [characterInfo, setCharacterInfo] = useState([]);
   const [rollQueue, setRollQueue] = useState([]);
   const [skills, setSkills] = useState([]);
 
+  // Ah, I bet I can't make the call to the DB if I don't know the character ID... and I haven't made any character calls yet.  Right?  
+    // Well, sorta.  I make a call to /characters/1 for axel prose, but when navigating directly there, I make a call to /characters/axel-prose.  
+    // So, if I could change the DB structure to accept axel-prose as the location, cool.  Otherwise... do I need to make a call to load characters?  
+    // Conditionally call the /characters endpoint if props.character is undefined?  IT seems like things are initially undefined, but then eventually catch up.  
   useEffect(() => {
-    fetch('http://localhost:3002/skills')
+    fetch(`http://localhost:3002/characters/${character.id}`)
       .then(res => res.json())
-      .then(skills => setSkills(skills)
-      )
-  }, [])
-
-  useEffect(() => {
-    fetch('http://localhost:3002/characters/1')
-      .then(res => res.json())
-      .then(characterInfo => setCharacterInfo(characterInfo)
+      .then(characterInfo => (setSkills(characterInfo.skills), setCharacterInfo(characterInfo))
       )
   }, [])
 
@@ -58,32 +55,55 @@ export default withStyles(styles)(({classes, rollMethods, botchActive}) => {
 
   const { wildDie } = characterInfo;
 
+
+  // So, based on whether the characterInfo array is empty, I can display content.  
+  // I'll need to create buttons for selecting a character and based on the character selected, tie that to the useEffect I call to fetch character info.  
+  // Then I'll save the fetched characterInfo, which will update my state, which will cause the normal components to load.  
+  // Unless something with routes makes more sense?  
+  // I suppose it would allow me to update the path to /skill-rolling/characterName.  
+  // And that would be a pattern I can continue to follow for advancement/characterName.  Further, once that state is higher up (or in Redux?) it will allow
+    // me to automatically route to the correct display for specific characters (because I can create a path based on the character name).  
   return (
-    <Grid container 
-      className={classes.pageStyle}
-      direction="column"
-    >
-      <CharacterDetails 
-        className={classes.characterDetails}
-        characterInfo={characterInfo}
-      />
-      <Grid container className={classes.rollers}>
-        <Grid item sm>
-          <SkillList 
-            skills={skills} 
-            addToRollQueue={rollQueueMethods.addToRollQueue}
-          />
-        </Grid>
-        <Grid item sm>
-          <RollingList 
-            rollQueue={rollQueue}
-            rollQueueMethods={rollQueueMethods}
-            rollMethods={rollMethods}
-            wildDie={wildDie} // This feels like it should be global and that I don't need to pass it down... 
-            botchActive={botchActive}
-          /> 
+    <>
+      {/* {console.log(availableCharacters)}
+      <br />
+      <br />
+      <br />
+
+      <div>{availableCharacters.map(({ id, characterName }) => 
+      <li key={id}>
+        {characterName}
+      </li>)}  </div> */}
+      {console.log(`skills: ${skills}`)}
+      {console.log(`characterInfo: ${characterInfo}`)}
+
+
+      <Grid container 
+        className={classes.pageStyle}
+        direction="column"
+      >
+        <CharacterDetails 
+          className={classes.characterDetails}
+          characterInfo={characterInfo}
+        />
+        <Grid container className={classes.rollers}>
+          <Grid item sm>
+            <SkillList 
+              skills={skills} 
+              addToRollQueue={rollQueueMethods.addToRollQueue}
+            />
+          </Grid>
+          <Grid item sm>
+            <RollingList 
+              rollQueue={rollQueue}
+              rollQueueMethods={rollQueueMethods}
+              rollMethods={rollMethods}
+              wildDie={wildDie} // This feels like it should be global and that I don't need to pass it down... 
+              botchActive={botchActive}
+            /> 
+          </Grid>
         </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 })

--- a/diceRoller/src/services/db.json
+++ b/diceRoller/src/services/db.json
@@ -95,6 +95,7 @@
   "characters": [
     {
       "id": 0,
+      "playReady": false,
       "characterName": "Template Character", 
       "rank": "Novice",
       "wounds": 0,
@@ -127,6 +128,7 @@
     },
     {
       "id": 1,
+      "playReady": true,
       "characterName": "Axel Prose", 
       "rank": "Novice",
       "wounds": 0,
@@ -138,18 +140,141 @@
       "parry":2,
       "attributes": {
         "agility": 4,
-        "smarts": 4, 
-        "spirit": 4,
-        "strength": 4,
+        "smarts": 10, 
+        "spirit": 6,
+        "strength": 6,
         "vigor": 4
       }, 
-      "skills": {
-        "athletics": 4,
-        "knowledge": 4,
-        "notice": 4,
-        "persuasion": 4,
-        "stealth": 4
-      }
+      "skills": [
+        {
+          "id": "athletics",
+          "name": "athletics",
+          "dieType": 6,
+          "associatedAttribute": "agility",
+          "twelveModifier": null,
+          "description": "Basic moving."
+        },{
+          "id": "knowledge",
+          "name": "knowledge",
+          "dieType": 8,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Whatcha know."
+        },{          
+          "id": "notice",
+          "name": "notice",
+          "dieType": 10,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Your general awareness"
+        },{          
+          "id": "persuasion",
+          "name": "persuasion",
+          "dieType": 4,
+          "associatedAttribute": "spirit",
+          "twelveModifier": null,
+          "description": "Convincing others"
+        },{          
+          "id": "stealth",
+          "name": "stealth",
+          "dieType": 4,
+          "associatedAttribute": "agility",
+          "twelveModifier": null,
+          "description": "Sneaks"
+        },{          
+          "id": "fighting",
+          "name": "fighting",
+          "dieType": 4,
+          "associatedAttribute": "agility",
+          "twelveModifier": null,
+          "description": "Holding your own"
+        },{          
+          "id": "research",
+          "name": "research",
+          "dieType": 6,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Finding info"
+        }
+      ], 
+      "hindrances": [],
+      "edges": [],
+      "gear": []
+    },
+    {
+      "id": 2,
+      "playReady": true,
+      "characterName": "Barnaby Jones", 
+      "rank": "Novice",
+      "wounds": 0,
+      "wildDie": 6,
+      "experience": 0,
+      "bennies": 3,
+      "pace": 6,
+      "toughness": 2,
+      "parry":2,
+      "attributes": {
+        "agility": 4,
+        "smarts": 10, 
+        "spirit": 6,
+        "strength": 4,
+        "vigor": 6
+      }, 
+      "skills": [
+        {
+          "id": "athletics",
+          "name": "athletics",
+          "dieType": 6,
+          "associatedAttribute": "agility",
+          "twelveModifier": null,
+          "description": "Basic moving."
+        },{
+          "id": "knowledge",
+          "name": "knowledge",
+          "dieType": 10,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Whatcha know."
+        },{          
+          "id": "notice",
+          "name": "notice",
+          "dieType": 8,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Your general awareness"
+        },{          
+          "id": "persuasion",
+          "name": "persuasion",
+          "dieType": 8,
+          "associatedAttribute": "spirit",
+          "twelveModifier": null,
+          "description": "Convincing others"
+        },{          
+          "id": "stealth",
+          "name": "stealth",
+          "dieType": 4,
+          "associatedAttribute": "agility",
+          "twelveModifier": null,
+          "description": "Sneaks"
+        },{          
+          "id": "intimidation",
+          "name": "intimidation",
+          "dieType": 6,
+          "associatedAttribute": "spirit",
+          "twelveModifier": null,
+          "description": "Aggressively swaying others"
+        },{          
+          "id": "hacking",
+          "name": "hacking",
+          "dieType": 8,
+          "associatedAttribute": "smarts",
+          "twelveModifier": null,
+          "description": "Breaking into computer systems"
+        }
+      ], 
+      "hindrances": [],
+      "edges": [],
+      "gear": []
     }
   ]
 }


### PR DESCRIPTION
User is able to select the character they'd like to roll skills for on the skill-roller tab.  The skills are also populated from the character object now instead of being pulled from a static skills object in the DB.  I am running into issues with refreshing or navigating directly to a character (i.e. /skill-roller/axel-prose); this is because that component makes a call to get character info, and really that should live in a parent component.  Rather than refactor that stuff prematurely, I'm going to implement Redux for state management and do it once.